### PR TITLE
chore: specify TypeScript as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@types/chrome": "^0.0.268"
       },
       "devDependencies": {
+        "typescript": "^5.5.3",
         "uglify-js": "^3.18.0"
       }
     },
@@ -37,6 +38,19 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.14.tgz",
       "integrity": "sha512-pEmBAoccWvO6XbSI8A7KvIDGEoKtlLWtdqVCKoVBcCDSFvR4Ijd7zGLu7MWGEqk2r8D54uWlMRt+VZuSrfFMzQ=="
+    },
+    "node_modules/typescript": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/uglify-js": {
       "version": "3.18.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@types/chrome": "^0.0.268"
   },
   "devDependencies": {
+    "typescript": "^5.5.3",
     "uglify-js": "^3.18.0"
   }
 }


### PR DESCRIPTION
Otherwise build fails for users that don't have it installed, or have a different version.

Also helps with versioning to make sure the build doesn't break with future versions of TypeScript.